### PR TITLE
[BE] 댓글 : 생성/조회/삭제 API 개발

### DIFF
--- a/polling-app-server/src/main/java/com/example/polls/controller/CommentController.java
+++ b/polling-app-server/src/main/java/com/example/polls/controller/CommentController.java
@@ -1,0 +1,55 @@
+package com.example.polls.controller;
+
+import com.example.polls.payload.Request.CommentRequest;
+import com.example.polls.payload.Response.ApiResponse;
+import com.example.polls.payload.Response.CommentResponse;
+import com.example.polls.payload.Response.PagedResponse;
+import com.example.polls.security.UserPrincipal;
+import com.example.polls.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/api/polls/{pollId}/comments")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping
+    public ResponseEntity<CommentResponse> createComment(
+            @PathVariable Long pollId,
+            @Valid @RequestBody CommentRequest commentRequest,
+            @AuthenticationPrincipal UserPrincipal userPrincipal){
+
+        CommentResponse commentResponse = commentService.createComment(
+                pollId, commentRequest, userPrincipal.getId());
+
+        return ResponseEntity.ok(commentResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<PagedResponse<CommentResponse>> getAllComments(
+            @PathVariable Long pollId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "10") int size){
+
+        PagedResponse<CommentResponse> response = commentService.getAllComment(pollId, userPrincipal.getId(), page, size);
+
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<ApiResponse> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal){
+
+        ApiResponse response = commentService.deleteComment(commentId, userPrincipal.getId());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/polling-app-server/src/main/java/com/example/polls/model/Comment.java
+++ b/polling-app-server/src/main/java/com/example/polls/model/Comment.java
@@ -1,0 +1,59 @@
+package com.example.polls.model;
+
+import com.example.polls.model.audit.DateAudit;
+import org.springframework.data.domain.Auditable;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "poll_comments")
+public class Comment extends DateAudit {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "poll_id", nullable = false)
+    private Poll poll;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Poll getPoll() {
+        return poll;
+    }
+
+    public void setPoll(Poll poll) {
+        this.poll = poll;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+}

--- a/polling-app-server/src/main/java/com/example/polls/payload/Request/CommentRequest.java
+++ b/polling-app-server/src/main/java/com/example/polls/payload/Request/CommentRequest.java
@@ -1,0 +1,15 @@
+package com.example.polls.payload.Request;
+
+import javax.validation.constraints.NotBlank;
+
+public class CommentRequest {
+    @NotBlank
+    private String content;
+
+    public String getContent() {
+        return content;
+    }
+    public void setContent(String content) {
+        this.content = content;
+    }
+}

--- a/polling-app-server/src/main/java/com/example/polls/payload/Response/CommentResponse.java
+++ b/polling-app-server/src/main/java/com/example/polls/payload/Response/CommentResponse.java
@@ -1,0 +1,32 @@
+package com.example.polls.payload.Response;
+
+public class CommentResponse {
+
+    private Long id;
+    private Long userId;
+    private String content;
+    private String createdAt;
+
+    public CommentResponse(Long id, Long userId, String content, String createdAt) {
+        this.id = id;
+        this.userId = userId;
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/polling-app-server/src/main/java/com/example/polls/repository/CommentRepository.java
+++ b/polling-app-server/src/main/java/com/example/polls/repository/CommentRepository.java
@@ -1,0 +1,16 @@
+package com.example.polls.repository;
+
+import com.example.polls.model.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+    List<Comment> findByPollIdOrderByCreatedAtDesc(Long pollId);
+
+    Page<Comment> findByPollId(Long pollId, Pageable pageable);
+}

--- a/polling-app-server/src/main/java/com/example/polls/service/CommentService.java
+++ b/polling-app-server/src/main/java/com/example/polls/service/CommentService.java
@@ -1,0 +1,112 @@
+package com.example.polls.service;
+
+
+import com.example.polls.exception.ResourceNotFoundException;
+import com.example.polls.model.Comment;
+import com.example.polls.model.Poll;
+import com.example.polls.model.User;
+import com.example.polls.payload.Request.CommentRequest;
+import com.example.polls.payload.Response.ApiResponse;
+import com.example.polls.payload.Response.CommentResponse;
+import com.example.polls.payload.Response.PagedResponse;
+import com.example.polls.repository.CommentRepository;
+import com.example.polls.repository.PollRepository;
+import com.example.polls.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+    private final PollRepository pollRepository;
+    private final UserRepository userRepository;
+
+    public CommentResponse createComment(Long pollId, CommentRequest commentRequest, Long userId){
+        Poll poll = pollRepository.findById(pollId)
+                .orElseThrow(()-> new ResourceNotFoundException("Poll", "id", pollId));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new ResourceNotFoundException("User", "id", userId));
+
+        Comment comment = new Comment();
+        comment.setContent(commentRequest.getContent());
+        comment.setPoll(poll);
+        comment.setUser(user);
+
+        Comment savedComment = commentRepository.save(comment);
+
+        // 5. 응답 DTO 생성
+
+        Instant createdAt = savedComment.getCreatedAt();
+        LocalDateTime ldt = LocalDateTime.ofInstant(createdAt, ZoneId.systemDefault());
+        String createdAtFormatted = ldt.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+
+
+        return new CommentResponse(
+                savedComment.getId(),
+                user.getId(),
+                savedComment.getContent(),
+                createdAtFormatted
+        );
+
+    }
+
+    public PagedResponse<CommentResponse> getAllComment(Long pollId, Long userId, int page, int size) {
+
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+        Page<Comment> comments = commentRepository.findByPollId(pollId, pageable);
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+        List<CommentResponse> commentResponses = comments.getContent().stream()
+                .map(comment -> {
+                    String createdAtFormatted = LocalDateTime.ofInstant(
+                            comment.getCreatedAt(), ZoneId.systemDefault()
+                    ).format(formatter);
+
+        return new CommentResponse(
+                comment.getId(),
+                comment.getUser().getId(),
+                comment.getContent(),
+                createdAtFormatted
+
+        );
+                })
+                .collect(Collectors.toList());
+
+        return new PagedResponse<>(
+                commentResponses,
+                comments.getNumber(),
+                comments.getSize(),
+                comments.getTotalElements(),
+                comments.getTotalPages(),
+                comments.isLast());
+
+    }
+
+    public ApiResponse deleteComment(Long commentId, Long userId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(()-> new ResourceNotFoundException("Comment", "id", commentId));
+
+        if(!comment.getUser().getId().equals(userId)){
+            throw new ResourceNotFoundException("Comment", "id", commentId);
+        }
+
+        commentRepository.delete(comment);
+
+        return new ApiResponse(true, "comment deleted");
+    }
+}


### PR DESCRIPTION
## 작업내용
- 댓글 생성 API(POST /api/polls/{pollId}/comments)
- 댓글 조회 API(GET /api/polls/{pollId}/comments)
- 댓글 삭제 API(DELETE /api/polls/{pollId}/comments/{commentId})

## 테스트방법
- Postman으로 단건 생성/조회 테스트 완료

## 참고
- 본 PR은 poll-core 브랜치 기준에서 직렬 개발되었으며, 현재는 develop 기반으로 rebase한 상태입니다.