### PR TITLE
[UPDATE] 그룹 상세 응답: 이미지 및 멤버 수 필드 추가

### DIFF
--- a/polling-app-client/src/components/MyGroups/MyGroups.jsx
+++ b/polling-app-client/src/components/MyGroups/MyGroups.jsx
@@ -1,0 +1,58 @@
+import React, { Component } from "react";
+import { ACCESS_TOKEN } from '../../constants';
+import "./MyGroups.css";
+import { getMyGroups } from '../../util/APIUtils';
+
+class MyGroups extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      groups: [],
+      loading: true,
+      error: null,
+    };
+  }
+
+  componentDidMount() {
+    const token = localStorage.getItem(ACCESS_TOKEN);
+
+    getMyGroups()
+    .then((data) => {
+      this.setState({ groups: data, loading: false });
+    })
+    .catch((error) => {
+      this.setState({ error: error.message || "에러 발생", loading: false });
+    });
+  }
+
+  render() {
+    const { groups, loading, error } = this.state;
+
+    return (
+      <div className="my-groups-container">
+        <h3>참여 중인 그룹</h3>
+        {loading ? (
+          <p>로딩 중...</p>
+        ) : error ? (
+          <p className="error">{error}</p>
+        ) : groups.length === 0 ? (
+          <p>참여한 그룹이 없습니다.</p>
+        ) : (
+          <div className="group-card-list">
+            {groups.map((group) => (
+              <div key={group.id} className="group-card">
+                <div className="group-avatar" />
+                <div className="group-info">
+                  <div className="group-name">{group.name}</div>
+                  <div className="group-count">멤버 {group.memberCount}명</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+export default MyGroups;

--- a/polling-app-client/src/util/APIUtils.js
+++ b/polling-app-client/src/util/APIUtils.js
@@ -117,3 +117,10 @@ export function getUserVotedPolls(username, page, size) {
         method: 'GET'
     });
 }
+
+export function getMyGroups() {
+    return request({
+        url: API_BASE_URL + "/groups/my",
+        method: 'GET'
+    });
+}

--- a/polling-app-server/src/main/java/com/example/polls/payload/Response/GroupSummaryResponse.java
+++ b/polling-app-server/src/main/java/com/example/polls/payload/Response/GroupSummaryResponse.java
@@ -9,12 +9,23 @@ public class GroupSummaryResponse {
     private String name;
     private String imageUrl;
     private String joinCode;
+    private int memberCount;
 
     public GroupSummaryResponse(Group group) {
         this.id = group.getId();
         this.name = group.getName();
         this.joinCode = group.getJoinCode();
         this.imageUrl = group.getImageUrl();
+        this.memberCount = group.getMembers().size();
+
+    }
+
+    public int getMemberCount() {
+        return memberCount;
+    }
+
+    public void setMemberCount(int memberCount) {
+        this.memberCount = memberCount;
     }
 
     public Long getId() {

--- a/polling-app-server/src/main/java/com/example/polls/service/GroupService.java
+++ b/polling-app-server/src/main/java/com/example/polls/service/GroupService.java
@@ -28,6 +28,7 @@ public class GroupService {
     private final GroupRepository groupRepository;
     private final UserRepository userRepository;
     private final GroupMemberRepository groupMemberRepository;
+    private static final String DEFAULT_GROUP_IMAGE_URL = "https://icons8.com/icon/DqsRVHkElCJ5/user-group";
 
     @Transactional
     public GroupSummaryResponse createGroup(CreateGroupRequest request,
@@ -35,11 +36,15 @@ public class GroupService {
         //참여 코드 생성
         String joinCode = generateUniqueJoinCode();
 
+        String imageUrl = (request.getImageUrl() == null || request.getImageUrl().isBlank())
+                ? DEFAULT_GROUP_IMAGE_URL
+                : request.getImageUrl();
+
         //그룹 엔티티 생성
         Group group = new Group();
         group.setName(request.getName());
         group.setDescription(request.getDescription());
-        group.setImageUrl(request.getImageUrl());
+        group.setImageUrl(imageUrl);
         group.setJoinCode(joinCode);
 
         //그룹저장

--- a/polling-app-server/src/main/resources/application.properties
+++ b/polling-app-server/src/main/resources/application.properties
@@ -2,11 +2,6 @@
 server.port= 8080
 server.compression.enabled=true
 
-#Debug
-logging.level.org.springframework.web=DEBUG
-logging.level.com.example=DEBUG
-
-
 ## Spring DATASOURCE (DataSourceAutoConfiguration & DataSourceProperties)
 spring.datasource.url= jdbc:mysql://localhost:3306/polling_app?useSSL=false&serverTimezone=UTC&useLegacyDatetimeCode=false
 spring.datasource.username= root


### PR DESCRIPTION
## 작업내용
- 그룹 상세 조회 API 응답에 memberCount 필드 추가
- imageUrl이 null일 경우 기본 이미지 URL("https://icons8.com/icon/DqsRVHkElCJ5/user-group") 자동 설정
- 프론트엔드 그룹 상세 화면에서 멤버 수 표시 추가

## 테스트 확인
- postman에서 null 일 경우 기본 url 생성 확인 완료

## 참고
- frontend/home-page 병합 시, 충돌 발생할 수 있습니다. 충돌할 경우 이 코드로 병합